### PR TITLE
fix(check_secrets): rewrite sed provider — was flagging non-secrets

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -77,7 +77,15 @@ function check_secrets {
     git secrets --add "credential_secret:\s?[\'\"]?\w+[\'\"]?\n?"
 
     if [ "$(bashio::config 'check.check_for_secrets')" == 'true' ]; then
-        git secrets --add-provider -- sed '/^$/d;/^#.*/d;/^&/d;s/^.*://g;s/\s//g' /config/secrets.yaml
+        # Extract leaf values from /config/secrets.yaml and add them as
+        # git-secrets patterns. See utils/extract_secret_values.py for the
+        # filtering rules (regex-escape, skip booleans/numbers/short values).
+        # The previous inline `sed` version was buggy in three ways:
+        #   1. `s/\s//g` deleted the letter 's' from every value.
+        #   2. Values were unescaped, so `.` matched any char.
+        #   3. No length/type filter → `port: 8123` matched the default HA port
+        #      everywhere and `true`/`false` matched every boolean.
+        git secrets --add-provider -- /utils/extract_secret_values.py /config/secrets.yaml
     fi
 
     if [ "$(bashio::config 'check.check_for_ips')" == 'true' ]; then

--- a/git-exporter/root/utils/extract_secret_values.py
+++ b/git-exporter/root/utils/extract_secret_values.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Extract leaf values from secrets.yaml as safe git-secrets patterns.
+
+Reads /config/secrets.yaml (or the path passed as argv[1]) line-by-line
+and prints one regex-escaped pattern per line to stdout, suitable for
+feeding to `git secrets --add-provider`.
+
+Skips values that would cause massive false-positive rates:
+  - empty values, YAML anchors/aliases, comments
+  - booleans (true/false/yes/no/on/off/null/~)
+  - purely numeric values (int or float)
+  - values shorter than MIN_LENGTH characters (default 8)
+
+Regex-escapes the value before printing so metacharacters like '.' and
+'/' don't behave as wildcards downstream.
+
+This replaces the historical one-line sed provider whose bugs were:
+  1. `s/\\s//g` deleted the letter 's' from every value (POSIX sed
+     treats `\\s` as a literal 's', not as `[[:space:]]`).
+  2. Values were emitted unescaped, so `43.6108` became a regex where
+     `.` matched any char.
+  3. No length / type filter, so `port: 8123` blocked every config that
+     mentioned the default HA port.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+MIN_LENGTH = 8
+BOOL_LIKE = {"true", "false", "yes", "no", "on", "off", "null", "~", ""}
+NUMERIC_RE = re.compile(r"[-+]?\d+(\.\d+)?([eE][-+]?\d+)?")
+
+
+def _leaf_value(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or stripped.startswith("&"):
+        return None
+    if ":" not in stripped:
+        return None
+    value = stripped.split(":", 1)[1].strip()
+    if not value:
+        return None
+    # strip inline comment
+    if " #" in value:
+        value = value.split(" #", 1)[0].rstrip()
+    # strip surrounding quotes
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("\"", "'"):
+        value = value[1:-1]
+    if value.lower() in BOOL_LIKE:
+        return None
+    if NUMERIC_RE.fullmatch(value):
+        return None
+    if len(value) < MIN_LENGTH:
+        return None
+    return value
+
+
+def main() -> int:
+    path = sys.argv[1] if len(sys.argv) > 1 else "/config/secrets.yaml"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for raw in fh:
+                value = _leaf_value(raw.rstrip("\n"))
+                if value is not None:
+                    print(re.escape(value))
+    except FileNotFoundError:
+        # No secrets.yaml → nothing to protect against, silent no-op.
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__/

--- a/tests/test_extract_secret_values.py
+++ b/tests/test_extract_secret_values.py
@@ -1,0 +1,57 @@
+"""Unit tests for utils/extract_secret_values.py"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+SCRIPT = pathlib.Path(__file__).parent.parent / "git-exporter" / "root" / "utils" / "extract_secret_values.py"
+
+
+def _run(content: str) -> list[str]:
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
+        fh.write(content)
+        path = fh.name
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def test_skips_boolean_numeric_and_short():
+    out = _run(
+        "port: 8123\n"
+        "enabled: true\n"
+        "short: abc\n"
+        "latitude: 43.6108\n"
+    )
+    assert out == []
+
+
+def test_keeps_long_alnum_values_and_regex_escapes():
+    out = _run(
+        'api_key: "abc123DEF456ghi789"\n'
+        'password: "Str0ng!Pa$$w0rd"\n'
+    )
+    assert "abc123DEF456ghi789" in out
+    # $ must be escaped so grep-secrets doesn't treat it as end-of-line
+    assert r"Str0ng!Pa\$\$w0rd" in out
+
+
+def test_skips_comments_and_blank_lines():
+    out = _run("# a comment\n\n\ngithub_token: ghp_ThisIsFakeXXXXXXXXXXXXX\n")
+    assert out == ["ghp_ThisIsFakeXXXXXXXXXXXXX"]
+
+
+def test_missing_file_is_noop():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "/nonexistent/secrets.yaml"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""


### PR DESCRIPTION
## Bug

When `check.check_for_secrets: true` is set, the addon crashes with `Found secrets in files!!!` and exits, flagging fields that are not secrets (`entity_id`, `device_id`, IDs, ports, booleans, ...).

Repro — a minimal `secrets.yaml`:

```yaml
latitude: 43.6108
longitude: 1.4442
port: 8123
enabled: true
name: "My House"
```

...will produce these git-secrets patterns from the current provider line in `run.sh`:

```
sed '/^$/d;/^#.*/d;/^&/d;s/^.*://g;s/\s//g' /config/secrets.yaml
```

Actual output on the above input:

```
 43.6108
 1.4442
 8123
 true
 "My Houe"       ← the 's' in "House" is gone
```

Then any file across `/config/**/*.yaml` that contains `43` + any-char + `6108`, or the substring `8123`, or the literal `true`, is reported as a leaked secret.

## Root causes

1. **`s/\s//g` deletes the letter `s`, not whitespace.** POSIX `sed` does not implement the `\s` escape — the backslash is silently dropped and it collapses to deleting every literal `s`. So `"My House"` becomes `"My Houe"`.
2. **Values are unescaped and used as regexes.** `43.6108` becomes the regex `43.6108`, where `.` is any-char. Anything that happens to contain `43X6108` triggers.
3. **No length or type filter.** `port: 8123` → the pattern `8123` matches every configuration.yaml that mentions the HA default frontend port. `enabled: true` → the pattern `true` matches every boolean in every YAML.

Consequence: on any real HA install with even a small `secrets.yaml`, `check_for_secrets: true` cannot succeed. The addon crashes, the export never runs.

## Fix

Replace the sed provider with a small Python extractor that:

- reads `secrets.yaml` line by line
- skips comments, empty lines, YAML anchors
- extracts the leaf value (post-`:`, quote-stripped)
- **skips** booleans (`true/false/yes/no/on/off/null/~`), pure numbers, and values shorter than 8 chars
- **regex-escapes** the value via `re.escape()` before printing

Same public interface — no config change, no behaviour change for users whose `secrets.yaml` only holds long random tokens/passwords (the intended use case).

Users whose `secrets.yaml` currently holds mixed metadata (lat/lng, ports, booleans) will stop seeing false-positive scan failures.

## Test

Four unit tests in `tests/test_extract_secret_values.py`:

- boolean, numeric, and too-short values are dropped
- long alnum values are kept
- values with regex metacharacters (`$`, `.`) are escaped
- missing `secrets.yaml` is a silent no-op

```
$ python3 -m pytest tests/ -v
tests/test_extract_secret_values.py::test_skips_boolean_numeric_and_short PASSED
tests/test_extract_secret_values.py::test_keeps_long_alnum_values_and_regex_escapes PASSED
tests/test_extract_secret_values.py::test_skips_comments_and_blank_lines PASSED
tests/test_extract_secret_values.py::test_missing_file_is_noop PASSED
============================== 4 passed in 0.11s ===============================
```

## Backwards compatibility

- No new addon config option.
- If the user's `secrets.yaml` is empty or missing → the old sed line produced no output either → same no-op.
- If the user's `secrets.yaml` holds real tokens (>= 8 chars, non-numeric, non-boolean) → both old and new behaviour add them as patterns. The new behaviour additionally regex-escapes them, so the check is strictly more correct.
- The only observable change is that short/numeric/boolean values that were being (buggily) added as patterns no longer are — they were producing false positives, not catching real secrets, so removing them is the intended fix.

## Related

Not the same bug as #5 (which is about unquoted `$(find …)` in the scan step and filenames with spaces). This one is upstream of the scan — it's the provider that populates `git secrets --add` before the scan runs.