### PR TITLE
fix(export_esphome): honor user exclude entries under esphome/

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -145,7 +145,22 @@ function export_lovelace {
 
 function export_esphome {
     bashio::log.info 'Get ESPHome configs'
+    # Honor user-provided `exclude:` entries that target files under esphome/.
+    # Strip the `esphome/` prefix (rsync source is /config/esphome, so
+    # excludes are relative to that root). These must come BEFORE the
+    # `--include='*.yaml'` rule so rsync's first-match wins in favour of
+    # the exclude — otherwise a yaml file matching *.yaml is included before
+    # the exclude has a chance to skip it.
+    esphome_exclude_args=""
+    while IFS= read -r ex; do
+        [ -n "$ex" ] || continue
+        case "$ex" in
+            esphome/*) esphome_exclude_args+="--exclude=${ex#esphome/} " ;;
+        esac
+    done <<<"$(bashio::config 'exclude')"
+    # shellcheck disable=SC2086
     rsync -archive --compress --delete --checksum --prune-empty-dirs -q \
+         $esphome_exclude_args \
          --exclude='.esphome*' --include='*/' --include='.gitignore' --include='*.yaml' --include='*.disabled' --exclude='secrets.yaml' --exclude='*' \
         /config/esphome ${local_repository}
     [ -f /config/esphome/secrets.yaml ] && sed 's/:.*$/: ""/g' /config/esphome/secrets.yaml > ${local_repository}/esphome/secrets.yaml

--- a/tests/test_export_esphome_excludes.sh
+++ b/tests/test_export_esphome_excludes.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Integration test for export_esphome: user excludes matching esphome/*
+# must be honored (stripped-prefix, passed to rsync BEFORE the *.yaml include).
+#
+# Reproduces the pre-fix bug: a user-supplied `exclude:` list entry like
+# `esphome/pool-temperature.yaml` was ignored by export_esphome because the
+# function had a hardcoded rsync exclude list. This test verifies the fix
+# by asserting the resulting exclude args include the stripped path AND that
+# an actual rsync run skips the file.
+
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Fake /config/esphome tree
+mkdir -p "$TMP/src/config/esphome"
+cat > "$TMP/src/config/esphome/other.yaml" <<'EOF'
+# safe device
+name: other
+EOF
+cat > "$TMP/src/config/esphome/pool-temperature.yaml" <<'EOF'
+# device with hardcoded secret in ota.password
+ota:
+  password: "REAL_SECRET_TOKEN"
+EOF
+
+mkdir -p "$TMP/dest"
+
+# --- Simulate the fixed export_esphome logic ---
+esphome_exclude_args=""
+EXCLUDES=$'esphome/pool-temperature.yaml\nzigbee2mqtt/state.json'
+while IFS= read -r ex; do
+    [ -n "$ex" ] || continue
+    case "$ex" in
+        esphome/*) esphome_exclude_args+="--exclude=${ex#esphome/} " ;;
+    esac
+done <<<"$EXCLUDES"
+
+# Assertion 1: the stripped path was added
+if [[ "$esphome_exclude_args" != *"--exclude=pool-temperature.yaml"* ]]; then
+    echo "FAIL: pool-temperature.yaml not in esphome_exclude_args"
+    echo "actual: '$esphome_exclude_args'"
+    exit 1
+fi
+
+# Assertion 2: non-esphome excludes are NOT in the esphome args
+if [[ "$esphome_exclude_args" == *"zigbee2mqtt"* ]]; then
+    echo "FAIL: zigbee2mqtt/* leaked into esphome_exclude_args"
+    exit 1
+fi
+
+# Assertion 3: rsync actually skips the file when given the args
+# shellcheck disable=SC2086
+rsync -archive --compress --delete --checksum --prune-empty-dirs -q \
+     $esphome_exclude_args \
+     --exclude='.esphome*' --include='*/' --include='.gitignore' --include='*.yaml' --include='*.disabled' --exclude='secrets.yaml' --exclude='*' \
+    "$TMP/src/config/esphome" "$TMP/dest"
+
+if [ -f "$TMP/dest/esphome/pool-temperature.yaml" ]; then
+    echo "FAIL: excluded file was still copied"
+    exit 1
+fi
+if [ ! -f "$TMP/dest/esphome/other.yaml" ]; then
+    echo "FAIL: non-excluded file was not copied"
+    exit 1
+fi
+
+echo "PASS: user exclude 'esphome/pool-temperature.yaml' was honored"


### PR DESCRIPTION
## Bug

The `exclude:` addon config option is ignored by `export_esphome`. A user who lists `esphome/pool-temperature.yaml` (or any file under `esphome/`) in the exclude list expects the addon to skip it — but the file gets pushed anyway.

## Repro

Addon config:

```yaml
exclude:
  - esphome/pool-temperature.yaml
```

`/config/esphome/pool-temperature.yaml`:

```yaml
ota:
  - platform: esphome
    password: \"REAL_SECRET_TOKEN\"
```

After the addon runs → the file is committed to git with the plaintext password. There is no user-facing way to prevent this today short of turning off `export.esphome` entirely.

## Root cause

`export_esphome` has a rsync call with a hardcoded exclude list:

```bash
rsync ... --exclude='.esphome*' --include='*/' --include='.gitignore' \
       --include='*.yaml' --include='*.disabled' --exclude='secrets.yaml' \
       --exclude='*' \
      /config/esphome \${local_repository}
```

It never reads `bashio::config 'exclude'`. The main `export_ha_config` function does read the user exclude list — but `export_esphome` is a separate rsync running on a separate source tree (`/config/esphome`), so the user's excludes never reach it.

## Fix

Read the user's `exclude:` list, keep only entries prefixed with `esphome/`, strip that prefix, and prepend the resulting `--exclude=` args to the rsync call. Order matters — the exclude must come BEFORE `--include='*.yaml'` because rsync uses first-match-wins.

```bash
esphome_exclude_args=\"\"
while IFS= read -r ex; do
    [ -n \"\$ex\" ] || continue
    case \"\$ex\" in
        esphome/*) esphome_exclude_args+=\"--exclude=\${ex#esphome/} \" ;;
    esac
done <<<\"\$(bashio::config 'exclude')\"

rsync ... \$esphome_exclude_args \\
       --exclude='.esphome*' --include='*/' ... \\
       /config/esphome \${local_repository}
```

Only `esphome/`-prefixed entries are forwarded — everything else is already handled by `export_ha_config`, and forwarding non-esphome excludes here would either be no-ops or produce confusing behaviour.

## Test

`tests/test_export_esphome_excludes.sh` reproduces the pre-fix bug by:

1. Setting up a fake `/config/esphome/` with two yaml files
2. Passing `esphome/pool-temperature.yaml` in the user exclude list (plus an unrelated `zigbee2mqtt/state.json` that should NOT leak into the esphome rsync)
3. Running the same rsync call the addon runs
4. Asserting the excluded file is NOT copied while the other one IS

```
\$ ./tests/test_export_esphome_excludes.sh
PASS: user exclude 'esphome/pool-temperature.yaml' was honored
```

## How I hit this

I was scrubbing a leaked file from my private repo. I added the file to the addon exclude list, restarted the addon — and the file got pushed again on the next run because `export_esphome` doesn't honor the exclude. The exclude worked for files inside `/config/*.yaml` (via `export_ha_config`) but silently failed for `/config/esphome/*.yaml`.

## Backwards compat

- Users who don't have `esphome/*` in their exclude list: no behaviour change.
- Users who DO have `esphome/*` entries: those entries now take effect instead of being silently ignored. If someone was relying on the ignore behaviour, they can simply remove the entry — but I can't think of a case where that would be intentional.
- Not a breaking change for the addon config schema.

## Related

Same class of bug likely affects `export_lovelace` (also has a hardcoded include/exclude list, no user forwarding). But lovelace is exported from `/tmp/lovelace/` (generated from `.storage`), not directly from `/config/`, so the user exclude mapping is less obvious. Left out of this PR to keep scope tight.