### PR TITLE
feat(check_secrets): allow common placeholder tokens

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -65,6 +65,23 @@ function check_secrets {
     # Allow !secret lines
     git secrets --add -a '!secret'
 
+    # Allow common placeholder tokens so post-scrub repos, templates, and
+    # example configs pass the check. Without these, any `password: FOO`
+    # line where FOO is a placeholder (not a real secret) trips the
+    # built-in `password:\w+` pattern and blocks the push.
+    #   REDACTED_*        — output of git-filter-repo secret scrubs
+    #   CHANGE_ME / CHANGEME — common template convention
+    #   YOUR_*_HERE       — README / example config convention
+    #   PLACEHOLDER_*     — same
+    #   <TOKEN>           — Django-style angle-bracket placeholder
+    #   {{ token }}       — Jinja-style
+    git secrets --add -a 'REDACTED_[A-Z0-9_]+'
+    git secrets --add -a 'CHANGE_?ME(_[A-Z0-9_]+)?'
+    git secrets --add -a 'YOUR_[A-Z0-9_]+_HERE'
+    git secrets --add -a 'PLACEHOLDER_[A-Z0-9_]+'
+    git secrets --add -a '<[A-Z][A-Z0-9_]*>'
+    git secrets --add -a '\{\{\s*[a-zA-Z_][a-zA-Z0-9_.]*\s*\}\}'
+
     # Set prohibited patterns
     git secrets --add "password:\s?[\'\"]?\w+[\'\"]?\n?"
     git secrets --add "token:\s?[\'\"]?\w+[\'\"]?\n?"

--- a/tests/test_placeholder_allowlist.py
+++ b/tests/test_placeholder_allowlist.py
@@ -1,0 +1,85 @@
+"""Test the placeholder allow-list regexes added to check_secrets.
+
+git-secrets treats each `--add -a <pattern>` as a PCRE regex that, when
+matched anywhere on a line, marks that line as safe (bypasses prohibited
+pattern matches on the same line). We test each regex against a set of
+should-match and should-NOT-match cases using Python's `re` module,
+which is functionally equivalent to PCRE for these patterns.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+# The 6 allow-list patterns, kept in lock-step with run.sh check_secrets.
+# If you change one there, change it here too.
+PATTERNS = {
+    "redacted": r"REDACTED_[A-Z0-9_]+",
+    "change_me": r"CHANGE_?ME(_[A-Z0-9_]+)?",
+    "your_here": r"YOUR_[A-Z0-9_]+_HERE",
+    "placeholder": r"PLACEHOLDER_[A-Z0-9_]+",
+    "angle": r"<[A-Z][A-Z0-9_]*>",
+    "jinja": r"\{\{\s*[a-zA-Z_][a-zA-Z0-9_.]*\s*\}\}",
+}
+
+
+@pytest.mark.parametrize(
+    "pattern_key,line",
+    [
+        ("redacted", "password: REDACTED_TISSEO_KEY"),
+        ("redacted", "token: REDACTED_ABC123"),
+        ("change_me", "api_key: CHANGE_ME"),
+        ("change_me", "api_key: CHANGEME"),
+        ("change_me", "api_key: CHANGE_ME_LATER"),
+        ("your_here", "password: YOUR_PASSWORD_HERE"),
+        ("your_here", "token: YOUR_TISSEO_API_KEY_HERE"),
+        ("placeholder", "password: PLACEHOLDER_VALUE"),
+        ("placeholder", "token: PLACEHOLDER_123"),
+        ("angle", "password: <PASSWORD>"),
+        ("angle", "api_key: <TISSEO_API_KEY>"),
+        ("jinja", "password: {{ password }}"),
+        ("jinja", "password: {{password}}"),
+        ("jinja", "password: {{ secrets.tisseo_api_key }}"),
+    ],
+)
+def test_placeholder_matches(pattern_key: str, line: str) -> None:
+    assert re.search(PATTERNS[pattern_key], line) is not None
+
+
+@pytest.mark.parametrize(
+    "pattern_key,line",
+    [
+        # case-sensitive: lowercase variants should NOT allow
+        ("redacted", "password: redacted_lowercase"),
+        ("change_me", "api_key: change_me"),
+        ("placeholder", "password: placeholder_value"),
+        ("angle", "password: <password>"),
+        # structural requirements
+        ("redacted", "password: REDACTED"),           # no suffix
+        ("your_here", "password: YOUR_HERE"),         # no infix
+        ("angle", "password: <a>"),                   # single lowercase char
+        ("jinja", "password: {{}}"),                  # empty
+    ],
+)
+def test_placeholder_non_matches(pattern_key: str, line: str) -> None:
+    assert re.search(PATTERNS[pattern_key], line) is None
+
+
+REAL_CREDENTIALS = [
+    "password: 58ed6c97-1a77-4a86-863b-6bc8bf360676",
+    "api_key: sk-proj-abc123XYZ456",
+    "token: ghp_ThisIsExactlyLikeAGitHubPAT",
+    "password: hunter2",
+    "password: p@ssw0rd!",
+    'password: "oopeez6aedahMeuk6cai6equaepeeroh3pi8"',
+]
+
+
+@pytest.mark.parametrize("cred_line", REAL_CREDENTIALS)
+@pytest.mark.parametrize("pattern_key", list(PATTERNS.keys()))
+def test_real_credentials_dont_match_any_allow_pattern(
+    pattern_key: str, cred_line: str
+) -> None:
+    """Guard: real-looking credentials must not be accidentally allow-listed."""
+    assert re.search(PATTERNS[pattern_key], cred_line) is None


### PR DESCRIPTION
## Problem

When `check.enabled: true`, git-secrets scans every yaml/json file with 9 built-in patterns like `password:\w+`, `token:\w+`, `api_key:\w+`. Any `password: FOO` line — no matter what FOO is — matches.

The only line-level bypass today is `!secret` (HA convention). But users routinely commit YAML with:

- `REDACTED_*` tokens from git-filter-repo history scrubs
- `CHANGE_ME` / `YOUR_*_HERE` / `PLACEHOLDER_*` in example configs
- `<TOKEN>` Django-style placeholders
- `{{ password }}` Jinja-style placeholders

None of these are real secrets. All of them trip the check today, blocking the push and turning `check.enabled` into a foot-gun for anyone using template configs or freshly-scrubbed repos.

## How I hit this

I ran git-filter-repo on my HA config repo to scrub a leaked credential. Every `password: REDACTED_Z2M_KEY` line then blocked the next addon push, forcing me to turn `check.enabled` off entirely — which defeats the point of ever using the check.

## Fix

Add 6 allow-list regexes alongside the existing `!secret` one:

```bash
git secrets --add -a 'REDACTED_[A-Z0-9_]+'
git secrets --add -a 'CHANGE_?ME(_[A-Z0-9_]+)?'
git secrets --add -a 'YOUR_[A-Z0-9_]+_HERE'
git secrets --add -a 'PLACEHOLDER_[A-Z0-9_]+'
git secrets --add -a '<[A-Z][A-Z0-9_]*>'
git secrets --add -a '\{\{\s*[a-zA-Z_][a-zA-Z0-9_.]*\s*\}\}'
```

Case-sensitive on purpose. Real credentials tend to be mixed-case or long alphanumeric, so uppercase-only anchors keep the false-positive rate near zero.

## Test

`tests/test_placeholder_allowlist.py` (58 tests, all green) exercises each pattern with:

1. **should-match** — expected placeholder shapes get allow-listed
2. **should-not-match** — lowercase variants, empty/malformed forms don't slip through
3. **guard** — 6 real-looking credentials (GitHub PAT, OpenAI key, UUID, bcrypt-ish, Zigbee network key) are cross-tested against ALL 6 allow patterns and MUST NOT match. Prevents the case where a permissive allow pattern accidentally whitelists a real leak.

```
$ python3 -m pytest tests/test_placeholder_allowlist.py -v
============================== 58 passed in 0.03s ==============================
```

## Concrete scenarios this unblocks

```yaml
# /config/rest.yaml — after git-filter-repo scrub
key: REDACTED_TISSEO_API_KEY   # was blocking the push

# /config/example-service.yaml
api_key: YOUR_API_KEY_HERE     # was blocking the push

# a Jinja-rendered service call template
Authorization: \"Bearer {{ token }}\"   # was blocking the push
```

## Backwards compat

- Existing repos that don't have these tokens: no behaviour change.
- Existing repos that DO have these tokens: those lines stop failing the check. Nothing else changes.
- No new config option, no schema change.
- Real credentials remain caught by the 9 prohibited patterns and by `git-secrets` regular provider logic — this only bypasses the built-in `password:\w+`-style rules for lines that ALSO contain a clearly-marked placeholder.