### PR TITLE
fix(export_lovelace): honor user exclude entries under lovelace/

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -139,7 +139,19 @@ function export_lovelace {
     mkdir -p '/tmp/lovelace'
     find /config/.storage -name "lovelace*" -printf '%f\n' | xargs -I % cp /config/.storage/% /tmp/lovelace/%.json
     /utils/jsonToYaml.py '/tmp/lovelace/' 'data'
-    rsync -archive --compress --delete --checksum --prune-empty-dirs -q --include='*.yaml' --exclude='*' /tmp/lovelace/ "${local_repository}/lovelace"
+    # Honor user-provided `exclude:` entries that target files under lovelace/.
+    # Rsync source is /tmp/lovelace (files named e.g. lovelace.dashboard_x.yaml)
+    # so we strip the `lovelace/` prefix. Excludes MUST come before the
+    # `--include='*.yaml'` rule — rsync uses first-match-wins.
+    lovelace_exclude_args=""
+    while IFS= read -r ex; do
+        [ -n "$ex" ] || continue
+        case "$ex" in
+            lovelace/*) lovelace_exclude_args+="--exclude=${ex#lovelace/} " ;;
+        esac
+    done <<<"$(bashio::config 'exclude')"
+    # shellcheck disable=SC2086
+    rsync -archive --compress --delete --checksum --prune-empty-dirs -q $lovelace_exclude_args --include='*.yaml' --exclude='*' /tmp/lovelace/ "${local_repository}/lovelace"
     chmod 644 -R "${local_repository}/lovelace"
 }
 

--- a/tests/test_export_lovelace_excludes.sh
+++ b/tests/test_export_lovelace_excludes.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Integration test for export_lovelace: user excludes matching lovelace/*
+# must be honored, same fix pattern as export_esphome.
+
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Fake /tmp/lovelace tree (flat — no subdirs, mirrors real behaviour)
+mkdir -p "$TMP/src"
+cat > "$TMP/src/lovelace.dashboard_public.yaml" <<'EOF'
+title: Public
+EOF
+cat > "$TMP/src/lovelace.dashboard_famille.yaml" <<'EOF'
+title: Family
+# has real lat/lng values that user wants to exclude
+latitude: 43.570758
+longitude: 1.5978114
+EOF
+
+mkdir -p "$TMP/dest"
+
+# --- Simulate the fixed export_lovelace logic ---
+lovelace_exclude_args=""
+EXCLUDES=$'lovelace/lovelace.dashboard_famille.yaml\nesphome/foo.yaml'
+while IFS= read -r ex; do
+    [ -n "$ex" ] || continue
+    case "$ex" in
+        lovelace/*) lovelace_exclude_args+="--exclude=${ex#lovelace/} " ;;
+    esac
+done <<<"$EXCLUDES"
+
+# Assertion 1: the stripped path was added
+if [[ "$lovelace_exclude_args" != *"--exclude=lovelace.dashboard_famille.yaml"* ]]; then
+    echo "FAIL: dashboard_famille not in lovelace_exclude_args"
+    echo "actual: '$lovelace_exclude_args'"
+    exit 1
+fi
+
+# Assertion 2: non-lovelace prefix entries don't leak
+if [[ "$lovelace_exclude_args" == *"esphome"* ]] || [[ "$lovelace_exclude_args" == *"foo.yaml"* ]]; then
+    echo "FAIL: esphome/foo.yaml leaked into lovelace_exclude_args"
+    exit 1
+fi
+
+# Assertion 3: rsync honors the exclude
+# shellcheck disable=SC2086
+rsync -archive --compress --delete --checksum --prune-empty-dirs -q \
+     $lovelace_exclude_args --include='*.yaml' --exclude='*' \
+    "$TMP/src/" "$TMP/dest/"
+
+if [ -f "$TMP/dest/lovelace.dashboard_famille.yaml" ]; then
+    echo "FAIL: excluded lovelace dashboard was still copied"
+    exit 1
+fi
+if [ ! -f "$TMP/dest/lovelace.dashboard_public.yaml" ]; then
+    echo "FAIL: non-excluded lovelace dashboard was not copied"
+    exit 1
+fi
+
+echo "PASS: user exclude 'lovelace/lovelace.dashboard_famille.yaml' was honored"


### PR DESCRIPTION
## Bug

Same shape as #7. The `exclude:` addon config option is ignored by `export_lovelace`. A user who lists `lovelace/lovelace.dashboard_famille.yaml` in the exclude list expects the addon to skip it — but the file gets pushed anyway.

## Repro

```yaml
# addon config
exclude:
  - lovelace/lovelace.dashboard_famille.yaml
```

Whatever's in `lovelace.dashboard_famille` (hardcoded coordinates for a location card, RTSP camera creds, a floor-plan with door codes, …) ends up in git on every sync.

## Root cause

`export_lovelace` has a rsync call with a hardcoded include/exclude list and never reads `bashio::config 'exclude'`. The main `export_ha_config` DOES read it — but lovelace is exported from `/tmp/lovelace/` (files generated from `/config/.storage/lovelace*` via `jsonToYaml.py`), so those excludes never reach this rsync.

## Fix

Parse the user exclude list, keep entries starting with `lovelace/`, strip the prefix, prepend to the rsync args BEFORE `--include='*.yaml'` (rsync first-match-wins).

Rsync source for lovelace is `/tmp/lovelace/` (flat, no subdirs). Filenames look like `lovelace.dashboard_famille.yaml`. That's what the user's `lovelace/lovelace.dashboard_famille.yaml` entry becomes after prefix strip — the two match cleanly.

```bash
lovelace_exclude_args=\"\"
while IFS= read -r ex; do
    [ -n \"\$ex\" ] || continue
    case \"\$ex\" in
        lovelace/*) lovelace_exclude_args+=\"--exclude=\${ex#lovelace/} \" ;;
    esac
done <<<\"\$(bashio::config 'exclude')\"

rsync ... \$lovelace_exclude_args --include='*.yaml' --exclude='*' ...
```

## Test

`tests/test_export_lovelace_excludes.sh` — same shape as the esphome test in #7. Sets up a fake `/tmp/lovelace/` with two dashboards, adds `lovelace/lovelace.dashboard_famille.yaml` to the user exclude list, runs the actual rsync, verifies the excluded one is skipped and the other is kept.

```
\$ ./tests/test_export_lovelace_excludes.sh
PASS: user exclude 'lovelace/lovelace.dashboard_famille.yaml' was honored
```

## Backwards compat

Same guarantees as #7. Users with no `lovelace/*` in their exclude list: no change. Users with such entries: they now take effect. No schema change.

## Related

- Companion to #7 (export_esphome same-class bug).
- `export_node-red` and `export_addons` also have their own rsync calls that don't forward user excludes. Left out of this PR to keep scope focused — happy to send follow-ups if the maintainer wants the whole set.