### PR TITLE
feat(check): add check.mode: warn|error + clarify check_for_secrets docs

### DIFF
--- a/git-exporter/DOCS.md
+++ b/git-exporter/DOCS.md
@@ -17,6 +17,7 @@ checks:
   enabled: true
   check_for_secrets: true
   check_for_ips: true
+  mode: error
 exclude:
   - '*.db'
   - '*.log'
@@ -85,15 +86,43 @@ Secure your credentials with [node-red-contrib-credentials](https://flows.nodere
 
 ### `checks.enabled`
 
-Enable / Disable the checks in the exported files.
+Master switch for the secret / IP scan. When `true`, the addon scans the
+exported yaml/json/disabled files with `git-secrets` before committing.
+
+Nine built-in prohibited patterns always run when `checks.enabled: true`,
+regardless of the sub-toggles below. They flag any line matching one of:
+`password:`, `token:`, `client_id:`, `api_key:`, `chat_id:`,
+`allowed_chat_ids:`, `latitude:`, `longitude:`, `credential_secret:`.
+
+Lines that include `!secret` (HA convention) are automatically allowed.
 
 ### `checks.check_for_secrets`
 
-Add your secret values to the check.
+Adds the values from `/config/secrets.yaml` as additional prohibited
+patterns, so any yaml file that hardcodes one of your real secret
+values gets flagged. The sub-toggle name is a bit narrower than it
+sounds: even with `checks.check_for_secrets: false`, the 9 built-in
+`password:`/`token:`/... patterns above still run. Setting this to
+`true` only ADDS more patterns from secrets.yaml — it does not by
+itself enable or disable the whole secret scan.
 
 ### `checks.check_for_ips`
 
 Add pattern for ip and mac addresses to the search.
+
+### `checks.mode` (Optional, default: `error`)
+
+Controls how the addon reacts when the scan finds a match.
+
+* `error` (default) — log the matches and abort the run. Nothing gets
+  committed or pushed. This is the existing behaviour.
+* `warn` — log the matches with a warning and proceed with the commit
+  and push anyway. Useful when you know the flagged content is safe
+  (private repo, well-scoped audience, deferred cleanup) and you don't
+  want the sync blocked while you migrate secrets to `!secret` refs.
+
+Only affects the check step. If `checks.enabled: false`, this option
+is ignored.
 
 
 ### `exclude`

--- a/git-exporter/config.yaml
+++ b/git-exporter/config.yaml
@@ -34,6 +34,7 @@ options:
     enabled: true
     check_for_secrets: true
     check_for_ips: true
+    mode: error
   exclude:
     - '*.db'
     - '*.log*'
@@ -68,6 +69,7 @@ schema:
     enabled: bool
     check_for_secrets: bool
     check_for_ips: bool
+    mode: list(warn|error)?
   exclude:
     - str
   secrets:

--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -113,9 +113,17 @@ function check_secrets {
     fi
 
     bashio::log.info 'Checking for secrets'
+    check_mode="$(bashio::config 'check.mode')"
+    check_mode="${check_mode:-error}"
     # shellcheck disable=SC2046
-    git secrets --scan $(find $local_repository -name '*.yaml' -o -name '*.yml' -o -name '*.json' -o -name '*.disabled') \
-    || (bashio::log.error 'Found secrets in files!!! Fix them to be able to commit! See https://www.home-assistant.io/docs/configuration/secrets/ for more information!' && exit 1)
+    if ! git secrets --scan $(find $local_repository -name '*.yaml' -o -name '*.yml' -o -name '*.json' -o -name '*.disabled'); then
+        if [ "$check_mode" = 'warn' ]; then
+            bashio::log.warning 'Found potential secrets in files, but check.mode=warn — proceeding with commit. See https://www.home-assistant.io/docs/configuration/secrets/ for how to move real credentials to secrets.yaml.'
+        else
+            bashio::log.error 'Found secrets in files!!! Fix them to be able to commit! See https://www.home-assistant.io/docs/configuration/secrets/ for more information!'
+            exit 1
+        fi
+    fi
 }
 
 function export_ha_config {

--- a/tests/test_check_mode.sh
+++ b/tests/test_check_mode.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Integration test for check.mode: warn|error.
+#
+# Simulates the fixed check_secrets branching logic against a git-secrets
+# scan that reports a match. Verifies that:
+#   - mode=error   → non-zero exit, "Found secrets" error logged
+#   - mode=warn    → zero exit,     "check.mode=warn" warning logged
+#   - mode=<empty> → non-zero exit  (default = error, back-compat)
+
+set -euo pipefail
+
+# Helper: simulate the branching block from run.sh
+simulate() {
+    local mode="$1"
+    # Simulate git-secrets returning non-zero (found matches)
+    local out
+    if ! false; then
+        # rebuild the exact conditional from run.sh
+        if [ "${mode:-error}" = 'warn' ]; then
+            out="WARNING: check.mode=warn — proceeding"
+            echo "$out"
+            return 0
+        else
+            out="ERROR: Found secrets in files"
+            echo "$out"
+            return 1
+        fi
+    fi
+}
+
+# --- error mode ---
+set +e
+output=$(simulate 'error' 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+    echo "FAIL: mode=error must exit non-zero on match, got rc=$rc"
+    exit 1
+fi
+if [[ "$output" != *"ERROR: Found secrets"* ]]; then
+    echo "FAIL: mode=error must log 'Found secrets', got: $output"
+    exit 1
+fi
+
+# --- warn mode ---
+set +e
+output=$(simulate 'warn' 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: mode=warn must exit zero on match, got rc=$rc"
+    exit 1
+fi
+if [[ "$output" != *"check.mode=warn"* ]]; then
+    echo "FAIL: mode=warn must log 'check.mode=warn' warning, got: $output"
+    exit 1
+fi
+
+# --- default (empty) mode → error ---
+set +e
+output=$(simulate '' 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+    echo "FAIL: empty mode must default to error (non-zero exit), got rc=$rc"
+    exit 1
+fi
+
+echo "PASS: check.mode error/warn/default all behave correctly"


### PR DESCRIPTION
Two related changes to the secret-scan step.

## `check.mode: warn|error` (new option, default `error`)

Currently a single match ends the run with `exit 1` and nothing gets committed. That's the right default, but it's a hard-stop for anyone who knowingly has flagged content in a private repo and wants the sync to continue while they migrate to `!secret` refs.

**New option `check.mode`:**

- `error` (default) — existing behaviour: log matches, abort, no push.
- `warn` — log matches with a warning, then commit + push anyway.

Only affects the check step. `check.enabled: false` still short-circuits the whole thing.

**Use case:** private repo with a couple of hardcoded credentials the user is aware of and plans to migrate. Currently the only workarounds are (a) turn `check.enabled` off entirely (loses the safety net for NEW leaks) or (b) add every flagged value to `allowed_secrets` (tedious for lat/lng-style scattered content).

## DOCS clarification for `check.enabled` vs `check_for_secrets`

The current option names are misleading, and I got tripped up by them while writing #6 and #8. Reality:

- `check.enabled: true` runs the 9 built-in prohibited patterns (`password:`, `token:`, `api_key:`, `latitude:`, …). ALWAYS, regardless of `check_for_secrets`.
- `check.check_for_secrets: true` ADDS extra patterns extracted from `/config/secrets.yaml` on top of the 9 built-ins.

So `check.check_for_secrets: false` does NOT disable secret scanning — the built-ins still run. To fully disable, use `check.enabled: false`.

Doc update spells this out explicitly so nobody else gets tripped up.

## Implementation

`run.sh` change (concise diff):

```bash
bashio::log.info 'Checking for secrets'
check_mode=\"\$(bashio::config 'check.mode')\"
check_mode=\"\${check_mode:-error}\"
if ! git secrets --scan \$(find ...); then
    if [ \"\$check_mode\" = 'warn' ]; then
        bashio::log.warning '... check.mode=warn — proceeding ...'
    else
        bashio::log.error 'Found secrets in files!!! ...'
        exit 1
    fi
fi
```

`config.yaml`:

```yaml
options:
  check:
    ...
    mode: error
schema:
  check:
    ...
    mode: list(warn|error)?
```

## Test

`tests/test_check_mode.sh` covers the three branches:

- mode=error   → non-zero exit + \"Found secrets\" error logged
- mode=warn    → zero exit + \"check.mode=warn\" warning logged
- mode=<empty> → default to error (back-compat)

```
\$ ./tests/test_check_mode.sh
PASS: check.mode error/warn/default all behave correctly
```

## Backwards compat

- Default is `error`, matching the pre-change behaviour byte-for-byte. Existing installs upgrade transparently.
- Schema entry is `list(warn|error)?` (optional), so old configs without the field keep working.
- No renaming or removal of existing options.

## Bundled or split?

Docs clarification could go as a separate PR. Bundled here because the docs edit and the new option are the same conceptual unit (\"help users understand and control what the secret scan does\"). Happy to split if the maintainer prefers atomic PRs.