### PR TITLE
fix(export_addons): honor user exclude entries under addons/

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -169,7 +169,18 @@ function export_addons {
       | jq '. | map(select(.source != null and .source != "core" and .source != "local")) | map({(.name): {source,maintainer,slug}}) | add' > /tmp/tmp.json
     /utils/jsonToYaml.py /tmp/tmp.json
     mv /tmp/tmp.yaml "/tmp/addons/repositories.yaml"
-    rsync -archive --compress --delete --checksum --prune-empty-dirs -q /tmp/addons/ ${local_repository}/addons
+    # Forward user excludes matching addons/ (strip prefix). One `.yaml` file
+    # is written per installed addon (${slug}.yaml), so users can skip a
+    # given addon's exported options by listing `addons/${slug}.yaml`.
+    addons_exclude_args=""
+    while IFS= read -r ex; do
+        [ -n "$ex" ] || continue
+        case "$ex" in
+            addons/*) addons_exclude_args+="--exclude=${ex#addons/} " ;;
+        esac
+    done <<<"$(bashio::config 'exclude')"
+    # shellcheck disable=SC2086
+    rsync -archive --compress --delete --checksum --prune-empty-dirs -q $addons_exclude_args /tmp/addons/ ${local_repository}/addons
     chmod 644 -R ${local_repository}/addons
 }
 

--- a/tests/test_export_addons_excludes.sh
+++ b/tests/test_export_addons_excludes.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Integration test for export_addons: user excludes matching addons/*
+# must be honored. Same shape as the esphome (#7) and lovelace (#9)
+# tests.
+
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/src"
+echo 'name: Foo Addon' > "$TMP/src/68413af6_foo.yaml"
+echo 'name: Bar Addon' > "$TMP/src/b67bc1f9_bar.yaml"
+echo 'repos: []' > "$TMP/src/repositories.yaml"
+
+mkdir -p "$TMP/dest"
+
+addons_exclude_args=""
+EXCLUDES=$'addons/68413af6_foo.yaml\nlovelace/x.yaml'
+while IFS= read -r ex; do
+    [ -n "$ex" ] || continue
+    case "$ex" in
+        addons/*) addons_exclude_args+="--exclude=${ex#addons/} " ;;
+    esac
+done <<<"$EXCLUDES"
+
+[[ "$addons_exclude_args" == *"--exclude=68413af6_foo.yaml"* ]] || { echo "FAIL: prefix strip"; exit 1; }
+[[ "$addons_exclude_args" == *"lovelace"* ]] && { echo "FAIL: lovelace/* leaked"; exit 1; }
+
+# shellcheck disable=SC2086
+rsync -archive --compress --delete --checksum --prune-empty-dirs -q \
+     $addons_exclude_args "$TMP/src/" "$TMP/dest/"
+
+[ ! -f "$TMP/dest/68413af6_foo.yaml" ] || { echo "FAIL: excluded file copied"; exit 1; }
+[ -f "$TMP/dest/b67bc1f9_bar.yaml" ]   || { echo "FAIL: kept file missing"; exit 1; }
+[ -f "$TMP/dest/repositories.yaml" ]   || { echo "FAIL: repositories.yaml missing"; exit 1; }
+
+echo "PASS"


### PR DESCRIPTION
Same shape as #7 (export_esphome) and #9 (export_lovelace). `export_addons` has its own rsync and does not forward the user's `exclude:` list.

## Change

Parse the user exclude list, keep entries starting with `addons/`, strip the prefix, prepend to the rsync call. One yaml is written per installed addon (`${slug}.yaml`), so an entry like `addons/68413af6_foo.yaml` maps cleanly after strip.

```bash
addons_exclude_args=""
while IFS= read -r ex; do
    [ -n "$ex" ] || continue
    case "$ex" in
        addons/*) addons_exclude_args+="--exclude=${ex#addons/} " ;;
    esac
done <<<"$(bashio::config 'exclude')"

rsync ... $addons_exclude_args /tmp/addons/ ${local_repository}/addons
```

## Test

`tests/test_export_addons_excludes.sh` — verifies prefix strip, non-addons entries don't leak, and the real rsync skips the excluded file.

```
$ ./tests/test_export_addons_excludes.sh
PASS
```

## Compat

Additive. Users without `addons/*` in their exclude list: no change. No schema change.

## Node-RED

Not included. `export_node-red` restricts to `flows.json` + `settings.js` and excludes everything else, so a user exclude has no additional file to target.