### PR TITLE
fix(check_secrets): quote find output so filenames with spaces work

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -113,9 +113,12 @@ function check_secrets {
     fi
 
     bashio::log.info 'Checking for secrets'
-    # shellcheck disable=SC2046
-    git secrets --scan $(find $local_repository -name '*.yaml' -o -name '*.yml' -o -name '*.json' -o -name '*.disabled') \
-    || (bashio::log.error 'Found secrets in files!!! Fix them to be able to commit! See https://www.home-assistant.io/docs/configuration/secrets/ for more information!' && exit 1)
+    # Use -print0 | xargs -0 so filenames with spaces (e.g. HACS theme
+    # `Liquid Glass.yaml`) are passed as single arguments rather than
+    # word-split by the shell.
+    find "$local_repository" \( -name '*.yaml' -o -name '*.yml' -o -name '*.json' -o -name '*.disabled' \) -print0 \
+        | xargs -0 --no-run-if-empty git secrets --scan \
+        || (bashio::log.error 'Found secrets in files!!! Fix them to be able to commit! See https://www.home-assistant.io/docs/configuration/secrets/ for more information!' && exit 1)
 }
 
 function export_ha_config {

--- a/tests/test_check_secrets_space_filenames.sh
+++ b/tests/test_check_secrets_space_filenames.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Regression test for #5. A filename with a space must be passed as
+# ONE argument to the scanner. Pre-fix the shell word-split the
+# `$(find ...)` output and the scan received two garbage paths.
+
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/repo/themes"
+: > "$TMP/repo/themes/Liquid Glass.yaml"
+: > "$TMP/repo/other.yaml"
+
+# Simulate what the fixed check_secrets does — pipe the find output as
+# separate args via -print0 | xargs -0. `printf %q\n` echoes what
+# xargs will actually pass, one per line.
+mapfile -t out < <(
+    find "$TMP/repo" \( -name '*.yaml' -o -name '*.yml' -o -name '*.json' -o -name '*.disabled' \) -print0 \
+        | xargs -0 -n1 printf '%s\n'
+)
+
+# Assertion: exactly 2 targets, and one of them is the space-in-name file
+if [ "${#out[@]}" -ne 2 ]; then
+    printf 'FAIL: expected 2 scan targets, got %d\n%s\n' "${#out[@]}" "$(printf '  %s\n' "${out[@]}")"
+    exit 1
+fi
+
+found=0
+for f in "${out[@]}"; do
+    [[ "$f" == *"Liquid Glass.yaml" ]] && found=1
+done
+if [ "$found" -ne 1 ]; then
+    printf 'FAIL: space-in-name file was word-split\ngot: %s\n' "$(printf '  %s\n' "${out[@]}")"
+    exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
Fixes #5.

`$(find ...)` in `check_secrets` was unquoted, so the shell word-split any filename containing a space (e.g. HACS theme `Liquid Glass.yaml`). `git secrets --scan` received two non-existent paths, exited non-zero, and the `||` branch reported it as "Found secrets" — a false positive that blocks the push.

## Change

```bash
# before
git secrets --scan $(find $local_repository -name '*.yaml' ...)

# after
find "$local_repository" \( -name '*.yaml' ... \) -print0 \
    | xargs -0 --no-run-if-empty git secrets --scan
```

`--no-run-if-empty` keeps behaviour sane on an empty repo (skip the scan instead of running `git secrets --scan` with no args).

## Test

`tests/test_check_secrets_space_filenames.sh` — creates `Liquid Glass.yaml` alongside `other.yaml`, runs the same `find ... -print0 | xargs -0` pipeline, asserts exactly 2 scan targets (not 3 from word-splitting).

```
$ ./tests/test_check_secrets_space_filenames.sh
PASS
```

## Compat

Behaviour-preserving for filenames without spaces. Repos with spaced filenames stop producing the false-positive block.