### PR TITLE
fix(export_node-red): honor user exclude entries under node-red/

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -175,7 +175,20 @@ function export_addons {
 
 function export_node-red {
     bashio::log.info 'Get Node-RED flows'
+    # Forward user excludes matching node-red/ (strip prefix). The rsync
+    # includes only flows.json + settings.js by default, but a user might
+    # still want to skip flows.json — e.g. a private flow set that shouldn't
+    # leave HA.
+    node_red_exclude_args=""
+    while IFS= read -r ex; do
+        [ -n "$ex" ] || continue
+        case "$ex" in
+            node-red/*) node_red_exclude_args+="--exclude=${ex#node-red/} " ;;
+        esac
+    done <<<"$(bashio::config 'exclude')"
+    # shellcheck disable=SC2086
     rsync -archive --compress --delete --checksum --prune-empty-dirs -q \
+          $node_red_exclude_args \
           --exclude='flows_cred.json' --exclude='*.backup' --include='flows.json' --include='settings.js' --exclude='*' \
         /config/node-red/ ${local_repository}/node-red
     chmod 644 -R ${local_repository}/node-red

--- a/tests/test_export_node_red_excludes.sh
+++ b/tests/test_export_node_red_excludes.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/src"
+echo '[]' > "$TMP/src/flows.json"
+echo 'module.exports={}' > "$TMP/src/settings.js"
+
+mkdir -p "$TMP/dest"
+
+node_red_exclude_args=""
+EXCLUDES=$'node-red/flows.json\nother/x.yaml'
+while IFS= read -r ex; do
+    [ -n "$ex" ] || continue
+    case "$ex" in
+        node-red/*) node_red_exclude_args+="--exclude=${ex#node-red/} " ;;
+    esac
+done <<<"$EXCLUDES"
+
+[[ "$node_red_exclude_args" == *"--exclude=flows.json"* ]] || { echo "FAIL: flows.json not in exclude args"; exit 1; }
+[[ "$node_red_exclude_args" == *"other"* ]] && { echo "FAIL: other/* leaked"; exit 1; }
+
+# shellcheck disable=SC2086
+rsync -archive --compress --delete --checksum --prune-empty-dirs -q \
+      $node_red_exclude_args \
+      --exclude='flows_cred.json' --exclude='*.backup' --include='flows.json' --include='settings.js' --exclude='*' \
+    "$TMP/src/" "$TMP/dest/"
+
+[ ! -f "$TMP/dest/flows.json" ] || { echo "FAIL: excluded flows.json copied"; exit 1; }
+[ -f "$TMP/dest/settings.js" ]  || { echo "FAIL: settings.js missing"; exit 1; }
+echo "PASS"


### PR DESCRIPTION
Completes the series after #7 (esphome), #9 (lovelace), #11 (addons). `export_node-red` also had its own rsync ignoring the user exclude list.

## Scope

Narrow — the rsync ships `flows.json` + `settings.js` by default and excludes everything else. But a user might still want to skip `flows.json` (e.g. private flow set that shouldn't leave HA). This aligns node-red with the other exports so the addon exclude schema is fully consistent.

## Change

Same shape as the previous three PRs: parse user exclude list, strip `node-red/` prefix, prepend to rsync.

## Test

`tests/test_export_node_red_excludes.sh`.