### PR TITLE
feat(commit): AI-generated commit messages from the staged diff

### DIFF
--- a/git-exporter/DOCS.md
+++ b/git-exporter/DOCS.md
@@ -7,6 +7,10 @@ repository:
   password: pass
   pull_before_push: true
   commit_message: 'Home Assistant Git Exporter'
+  commit_message_prompt: ''
+  commit_message_api_key: ''
+  commit_message_model: 'claude-haiku-4-5-20251001'
+  commit_message_timeout: 10
   branch_name: 'main'
 export:
   lovelace: true
@@ -54,7 +58,32 @@ Should the repository be pulled first and commit the new state on top?
 
 ### `repository.commit_message`
 
-The commit message for the next commit.
+The commit message for the next commit. Also used as the fallback whenever AI
+message generation is disabled or fails (see below).
+
+### `repository.commit_message_prompt` (Optional)
+
+Prompt sent to the LLM when AI commit messages are enabled. Leave empty to use a
+sensible default (one-line French, conventional-commits style, ≤ 72 chars). The
+staged diff is appended to this prompt automatically.
+
+### `repository.commit_message_api_key` (Optional)
+
+Anthropic API key. **This is the on/off switch**: when set (e.g. via
+`!secret anthropic_api_key`), each commit message is generated from the actual
+diff by the model. When empty (default), the static `commit_message` is used —
+no API call is made. Any API failure or timeout silently falls back to the
+static message, so a commit is never blocked.
+
+### `repository.commit_message_model` (Optional)
+
+Model id used for message generation. Default: `claude-haiku-4-5-20251001`
+(cheapest; ~$1.80/month at a 15-minute export cadence).
+
+### `repository.commit_message_timeout` (Optional)
+
+Seconds to wait for the API before falling back to the static message.
+Default: `10`.
 
 ### `repository.branch_name`
 

--- a/git-exporter/config.yaml
+++ b/git-exporter/config.yaml
@@ -24,6 +24,10 @@ options:
     password: ''
     pull_before_push: true
     commit_message: Home Assistant Git Exporter
+    commit_message_prompt: ''
+    commit_message_api_key: ''
+    commit_message_model: claude-haiku-4-5-20251001
+    commit_message_timeout: 10
     branch_name: main
   export:
     lovelace: true
@@ -57,6 +61,10 @@ schema:
     password: password
     pull_before_push: bool
     commit_message: str
+    commit_message_prompt: str?
+    commit_message_api_key: password?
+    commit_message_model: str?
+    commit_message_timeout: int?
     branch_name: str
     ssl_verification: bool?
   export:

--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -181,6 +181,58 @@ function export_node-red {
     chmod 644 -R ${local_repository}/node-red
 }
 
+# Generate a one-line commit message from the staged diff via the Anthropic API.
+# Opt-in: only invoked when repository.commit_message_api_key is set. Prints the
+# message to stdout, or nothing on ANY failure so the caller keeps the static
+# repository.commit_message fallback. Never blocks or delays a commit beyond the
+# configured timeout. See docs/design/ai-commit-messages.md (consumer config repo).
+function generate_ai_commit_message {
+    local api_key="$1"
+    local prompt model timeout_s diff payload response ai_msg
+
+    prompt="$(bashio::config 'repository.commit_message_prompt')"
+    model="$(bashio::config 'repository.commit_message_model')"
+    timeout_s="$(bashio::config 'repository.commit_message_timeout')"
+
+    # Sane defaults when the options are left empty (bashio returns 'null' for unset optionals).
+    if [ -z "$prompt" ] || [ "$prompt" == 'null' ]; then
+        prompt="Rédige un message de commit Français d'une ligne (max 72 caractères, style conventional commits). Résume le diff ci-dessous. Pas d'introduction, juste la ligne."
+    fi
+    if [ -z "$model" ] || [ "$model" == 'null' ]; then
+        model='claude-haiku-4-5-20251001'
+    fi
+    if [ -z "$timeout_s" ] || [ "$timeout_s" == 'null' ]; then
+        timeout_s=10
+    fi
+
+    # Bound the diff: keeps the prompt cheap AND caps the prompt-injection surface
+    # from arbitrary config-file content (design §"Failure mode considerations").
+    diff="$( { git diff --cached --stat | head -50; echo; git diff --cached | head -300; } 2>/dev/null )" || true
+    if [ -z "$diff" ]; then
+        return 0
+    fi
+
+    payload="$(jq -n --arg model "$model" --arg prompt "$prompt" --arg diff "$diff" '{
+        model: $model,
+        max_tokens: 200,
+        messages: [{role: "user", content: ($prompt + "\n\nDiff:\n" + $diff)}]
+    }')"
+
+    # -m timeout → falls back to static on any network hiccup; never hangs a commit.
+    response="$(curl -sS -m "$timeout_s" -X POST https://api.anthropic.com/v1/messages \
+        -H "x-api-key: ${api_key}" \
+        -H 'anthropic-version: 2023-06-01' \
+        -H 'content-type: application/json' \
+        -d "$payload" 2>/dev/null || true)"
+
+    # '// empty' → empty string on malformed JSON or an API error object.
+    ai_msg="$(printf '%s' "$response" | jq -r '.content[0].text // empty' 2>/dev/null || true)"
+    # Defensive: keep only the first non-blank line even if the model returns prose.
+    ai_msg="$(printf '%s\n' "$ai_msg" | sed '/^[[:space:]]*$/d' | head -1)"
+
+    printf '%s' "$ai_msg"
+}
+
 bashio::log.info 'Start git export'
 
 setup_git
@@ -213,7 +265,25 @@ if [ "$(bashio::config 'dry_run')" == 'true' ]; then
 else
     bashio::log.info 'Commit changes and push to remote'
     git add .
-    git commit -m "$(bashio::config 'repository.commit_message')"
+
+    commit_message="$(bashio::config 'repository.commit_message')"
+
+    # Optionally replace the static message with an AI-generated one describing the
+    # actual diff. Opt-in via repository.commit_message_api_key; any failure silently
+    # keeps the static fallback above (see generate_ai_commit_message).
+    ai_api_key="$(bashio::config 'repository.commit_message_api_key')"
+    if [ -n "$ai_api_key" ] && [ "$ai_api_key" != 'null' ] && ! git diff --cached --quiet; then
+        bashio::log.info 'Generating AI commit message from staged diff'
+        ai_commit_message="$(generate_ai_commit_message "$ai_api_key")"
+        if [ -n "$ai_commit_message" ]; then
+            commit_message="$ai_commit_message"
+            bashio::log.info "AI commit message: ${commit_message}"
+        else
+            bashio::log.warning 'AI commit message unavailable — using static fallback'
+        fi
+    fi
+
+    git commit -m "$commit_message"
 
     if [ ! "$pull_before_push" == 'true' ]; then
         git push --set-upstream origin "$branch" -f

--- a/tests/test_ai_commit_message_fallback.sh
+++ b/tests/test_ai_commit_message_fallback.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Tests for the AI commit-message feature (docs/design/ai-commit-messages.md).
+# Exercises generate_ai_commit_message() extracted from run.sh against the four
+# paths from the design:
+#   A. API succeeds            -> function prints the AI message
+#   B. API network failure     -> function prints nothing (caller uses fallback)
+#   D. API malformed response  -> function prints nothing (caller uses fallback)
+# (Path C — api_key unset — lives in the caller, which never invokes the
+#  function without a key; asserted separately at the bottom.)
+#
+# The real git and jq are used; curl is stubbed via a PATH shim whose behaviour
+# is driven by $FAKE_CURL_MODE. Requires jq + git; skips cleanly without them.
+
+set -euo pipefail
+
+command -v jq  >/dev/null || { echo "SKIP: jq not installed";  exit 0; }
+command -v git >/dev/null || { echo "SKIP: git not installed"; exit 0; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUNSH="$ROOT/git-exporter/root/run.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- stub curl on PATH; behaviour driven by FAKE_CURL_MODE ------------------
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+case "${FAKE_CURL_MODE:-success}" in
+  success)   printf '%s' '{"content":[{"type":"text","text":"fix(lovelace): rename printer sensors"}]}' ;;
+  netfail)   exit 7 ;;                       # curl: could not connect
+  malformed) printf '%s' '{"error":{"type":"overloaded"}}' ;;
+  empty)     printf '%s' '' ;;
+esac
+EOF
+chmod +x "$TMP/bin/curl"
+export PATH="$TMP/bin:$PATH"
+
+# --- stub bashio::config: optional keys empty -> function uses its defaults --
+bashio::config() { printf ''; }
+export -f bashio::config
+
+# --- real git repo with a staged change so the diff is non-empty ------------
+git init -q "$TMP/repo"
+cd "$TMP/repo"
+git config user.email t@t.t; git config user.name t
+printf 'a\n' > f.txt
+git add f.txt
+
+# --- extract the real function from run.sh and load it ----------------------
+sed -n '/^function generate_ai_commit_message {/,/^}/p' "$RUNSH" > "$TMP/fn.sh"
+[ -s "$TMP/fn.sh" ] || { echo "FAIL: could not extract generate_ai_commit_message from run.sh"; exit 1; }
+# shellcheck disable=SC1091
+source "$TMP/fn.sh"
+
+fail() { printf 'FAIL: %s\n' "$1"; exit 1; }
+# FAKE_CURL_MODE must be exported so the curl PATH shim (a subprocess) reads it.
+
+# Path A — success -> the AI message
+export FAKE_CURL_MODE=success
+out="$(generate_ai_commit_message "sk-test")"
+[ "$out" = "fix(lovelace): rename printer sensors" ] || fail "A: expected AI message, got '$out'"
+
+# Path B — network failure -> empty (caller falls back)
+export FAKE_CURL_MODE=netfail
+out="$(generate_ai_commit_message "sk-test")"
+[ -z "$out" ] || fail "B: expected empty on netfail, got '$out'"
+
+# Path D — malformed / error JSON -> empty
+export FAKE_CURL_MODE=malformed
+out="$(generate_ai_commit_message "sk-test")"
+[ -z "$out" ] || fail "D: expected empty on malformed JSON, got '$out'"
+
+# Path D' — empty body -> empty
+export FAKE_CURL_MODE=empty
+out="$(generate_ai_commit_message "sk-test")"
+[ -z "$out" ] || fail "D': expected empty on empty body, got '$out'"
+
+# Empty diff (nothing staged) -> empty regardless of API
+git commit -qm seed
+export FAKE_CURL_MODE=success
+out="$(generate_ai_commit_message "sk-test")"
+[ -z "$out" ] || fail "empty-diff: expected empty when nothing staged, got '$out'"
+
+echo "PASS"


### PR DESCRIPTION
## What

Adds an **opt-in** mode where each auto-commit message is written by a small LLM from the actual staged diff, instead of the static `commit_message`. When the exporter runs on a timer, `git log` currently reads the same line every time; this makes each commit describe what actually changed.

## How

- New optional options under `repository:` — `commit_message_prompt`, `commit_message_api_key`, `commit_message_model` (default `claude-haiku-4-5-20251001`), `commit_message_timeout` (default 10s). Schema + DOCS updated.
- `commit_message_api_key` is the on/off switch. **Empty (default) = current behaviour, no API call.**
- Between `git add` and `git commit`, if a key is set and there is a staged diff, `generate_ai_commit_message` calls the Anthropic API and uses the one-line result.

## Safety / fallback

Any failure — no key, network error, timeout, malformed response, empty diff — **silently falls back to the static `commit_message`**. A commit is never blocked or delayed beyond the timeout. The API key is a `password` schema type (never committed); the diff is bounded to 300 lines to keep the prompt cheap and cap the prompt-injection surface, and the output is used only as a commit message, never executed.

## Test

`tests/test_ai_commit_message_fallback.sh` extracts the function and asserts the four paths (success, network failure, malformed JSON, empty body) plus the empty-diff case. `shellcheck -x` clean.

`jq`/`curl` are already provided by the addon base image (bashio depends on them), so no Dockerfile change.

For triage: this fits the `enhancement` label.