### PR TITLE
fix: refresh origin URL each run so a rotated credential keeps working

### DIFF
--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -30,8 +30,9 @@ function setup_git {
         git config --global http.sslVerify false
     fi
 
+    fullurl="https://${username}:${password}@${repository##*https://}"
+
     if [ ! -d .git ]; then
-        fullurl="https://${username}:${password}@${repository##*https://}"
         if [ "$pull_before_push" == 'true' ]; then
             bashio::log.info 'Clone existing repository'
             git clone "$fullurl" $local_repository
@@ -43,6 +44,17 @@ function setup_git {
         fi
         git config user.name "${username}"
         git config user.email "${commiter_mail:-git.exporter@home-assistant}"
+    fi
+
+    # Always refresh the origin URL from the current add-on options so a
+    # rotated credential (e.g. a re-generated GitHub PAT) is picked up on
+    # every run. Without this the credential is embedded only at the first
+    # clone into the persistent /data/repository and never updated, so
+    # rotating the token silently breaks fetch/push until /data is wiped.
+    if git remote get-url origin >/dev/null 2>&1; then
+        git remote set-url origin "$fullurl"
+    else
+        git remote add origin "$fullurl"
     fi
 
     #Reset secrets if existing


### PR DESCRIPTION
## Problem

The git credential (`username:token`) is embedded in the `origin` URL **only at the first clone** into the persistent `/data/repository`, in the `if [ ! -d .git ]` block of `setup_git`. On every subsequent run that block is skipped (`.git` already exists) and the add-on just runs `git fetch` + `git reset --hard`, reusing the **originally embedded** credential.

As a result, **rotating the credential silently breaks the add-on**: after re-generating a GitHub fine-grained PAT (or any token/password change), `git fetch`/`push` fails with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for '.../repo.git'
```

Changing the `repository.password` option or restarting the add-on has **no effect**, because `/data/repository/.git/config` still holds the old URL. The only workaround today is to wipe `/data` (reinstall the add-on) to force a fresh clone. This is very hard to diagnose — the token itself is valid (`git ls-remote` with it works fine outside the add-on).

## Fix

Rebuild `fullurl` from the current add-on options on every run and `git remote set-url origin "$fullurl"` unconditionally (falling back to `git remote add` when origin is missing). A rotated credential is then picked up immediately, with no persistent-state surgery.

Minimal, backwards-compatible: on a fresh clone the URL is set to the same value it already had.

## Test

- Fresh install → clones and pushes normally.
- Rotate the PAT, update the option → next run picks up the new credential and pushes successfully (previously failed until reinstall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)